### PR TITLE
docs: Codacy for Code Quality

### DIFF
--- a/admin/cipipeline/Codacy.md
+++ b/admin/cipipeline/Codacy.md
@@ -1,0 +1,17 @@
+# For Future CI/CD Discussion (Not Currently Implemented)
+## What is Codacy?
+Codacy is a static code analysis tool that automatically reviews source code during the early stages of development to identify vulnerabilities, errors, and deviations from coding standards before the code is executed. Static code analysis helps developers catch issues early by examining the code itself rather than running it, making it easier to maintain clean, efficient, and secure codebases. Codacy also provides detailed reports and metrics, allowing teams to track code quality, enforce coding standards, and continuously improve their development workflows.
+
+## Why should we use it in our pipeline
+- **Free to use with easy Git integration**, making adding code quality checks directly into existing workflows simple.
+- **Available as a Visual Studio Code extension**, allowing developers to view, fix, and maintain code quality directly within their editor.
+- **Supports AI-driven coding practices**, where clean and consistent codebases are essential for effective AI code generation and collaboration.
+- **Provides automated reports and metrics** that help teams monitor, maintain, and improve code quality over time without manual effort.
+
+## How to use it 
+1) Go to [Codacy's Website](https://www.codacy.com/) and press on **Get Started**
+2) Sign in through GitHub, and give the program access to the repository we will be working with
+3) Configure settings to set a default coding standard
+4) View the repository analysis reports to see detected issues
+
+### To view a short demonstration [click here](https://youtu.be/wJPtuvwbdB0?si=nwetDwxdYl8Z0Tsd)


### PR DESCRIPTION
This document serves as an introduction for the team on using Codacy to maintain code quality. It can be used for future CI/CD addition discussions